### PR TITLE
Fix DocumentReference Identifiers.

### DIFF
--- a/lib/modifications.rb
+++ b/lib/modifications.rb
@@ -212,6 +212,11 @@ module DataScript
       end
       puts "  - Altered codes for #{all_docref.length} clinical notes."
 
+      all_docref.each do |docref|
+        docref&.identifier&.each {|id| id.value = "urn:uuid:#{id.value}" if (id.system == 'urn:ietf:rfc:3986' && !id.value&.start_with?('urn'))}
+      end
+      puts "  - Altered identifiers for #{all_docref.length} clinical notes."
+
       # select by medication
       selection_medication = results.find {|b| DataScript::Constraints.has(b, FHIR::Medication)}
       unless selection_medication


### PR DESCRIPTION
Fixes FHIR Identifiers with a system of `urn:ietf:rfc:3986` which require a value that is a URI with a proper prefix (e.g. `urn:uuid:`).

See http://hl7.org/fhir/R4/datatypes.html#Identifier and https://github.com/onc-healthit/inferno-program/issues/179
