### PR TITLE
Switch UCUM code for pulse ox to use capital L

### DIFF
--- a/lib/modifications.rb
+++ b/lib/modifications.rb
@@ -286,9 +286,9 @@ module DataScript
           pulse_ox_clone.component.last.code = create_codeable_concept('http://loinc.org','3151-8', 'Inhaled oxygen flow rate')
           pulse_ox_clone.component.last.valueQuantity = FHIR::Quantity.new
           pulse_ox_clone.component.last.valueQuantity.value = 6
-          pulse_ox_clone.component.last.valueQuantity.unit = 'l/min'
+          pulse_ox_clone.component.last.valueQuantity.unit = 'L/min'
           pulse_ox_clone.component.last.valueQuantity.system = 'http://unitsofmeasure.org'
-          pulse_ox_clone.component.last.valueQuantity.code = 'l/min'
+          pulse_ox_clone.component.last.valueQuantity.code = 'L/min'
           # Second component is concentration
           pulse_ox_clone.component << FHIR::Observation::Component.new
           pulse_ox_clone.component.last.code = create_codeable_concept('http://loinc.org','3150-0', 'Inhaled oxygen concentration')


### PR DESCRIPTION
Output before:
<img width="445" alt="Screen Shot 2020-12-02 at 10 07 58 AM" src="https://user-images.githubusercontent.com/49001/100890545-5d450b00-3486-11eb-855f-07d3834d8cde.png">

Output after:
<img width="457" alt="Screen Shot 2020-12-02 at 10 05 18 AM" src="https://user-images.githubusercontent.com/49001/100890562-61712880-3486-11eb-8a14-050cedbf734e.png">
