### PR TITLE
Migrate from using base FHIR Head Circumference resources to US Core-profiled resources

### DIFF
--- a/lib/choice_type_creator.rb
+++ b/lib/choice_type_creator.rb
@@ -35,7 +35,6 @@ module DataScript
         profiles: [
           'http://hl7.org/fhir/StructureDefinition/resprate',
           'http://hl7.org/fhir/StructureDefinition/heartrate',
-          'http://hl7.org/fhir/StructureDefinition/headcircum',
           'http://hl7.org/fhir/StructureDefinition/bodyweight',
           'http://hl7.org/fhir/StructureDefinition/bp',
           'http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus',
@@ -43,6 +42,7 @@ module DataScript
           'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab',
           'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age',
           'http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry',
+          'http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile',
           'http://hl7.org/fhir/StructureDefinition/bodyheight',
           'http://hl7.org/fhir/StructureDefinition/bodytemp'
         ]

--- a/lib/constraints.rb
+++ b/lib/constraints.rb
@@ -63,11 +63,11 @@ module DataScript
       'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height',
       'http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus',
       'http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry',
+      'http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile',
       'http://hl7.org/fhir/StructureDefinition/resprate',
       'http://hl7.org/fhir/StructureDefinition/heartrate',
       'http://hl7.org/fhir/StructureDefinition/bodytemp',
       'http://hl7.org/fhir/StructureDefinition/bodyheight',
-      'http://hl7.org/fhir/StructureDefinition/headcircum',
       'http://hl7.org/fhir/StructureDefinition/bodyweight',
       'http://hl7.org/fhir/StructureDefinition/bmi',
       'http://hl7.org/fhir/StructureDefinition/bp'
@@ -143,6 +143,14 @@ module DataScript
     def self.has_pulse_ox(bundle)
       bundle.entry.any? do |entry|
         entry.resource&.meta&.profile&.include? 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry'
+      end
+    end
+
+    def self.has_headcircum(results)
+      results.any? do |bundle|
+        bundle.entry.any? do |entry|
+          entry.resource&.meta&.profile&.include? 'http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile'
+        end
       end
     end
   end

--- a/uscore-data-script.rb
+++ b/uscore-data-script.rb
@@ -38,7 +38,7 @@ CLASSPATH='lib/synthea/synthea.jar:lib/synthea/SimulationCoreLibrary_v1.5_slim.j
 CONFIG='--exporter.fhir.use_us_core_ig=true --exporter.baseDirectory=./output/raw --exporter.hospital.fhir.export=false --exporter.practitioner.fhir.export=false --exporter.groups.fhir.export=true'
 
 if MRBURNS
-  system( "java -cp #{CLASSPATH} App -s #{RAND_SEED} -a 80-81 -g M -p 30 #{CONFIG} --exporter.years_of_history=0 > output/synthea.log" )
+  system( "java -cp #{CLASSPATH} App -s #{RAND_SEED} -a 80-81 -g M -p 50 #{CONFIG} --exporter.years_of_history=0 > output/synthea.log" )
 else
   system( "java -cp #{CLASSPATH} App -s #{RAND_SEED} -p 160 #{CONFIG} > output/synthea.log" )
 end


### PR DESCRIPTION
This PR removes any base-FHIR "Head Circumference" resources, and any references to their profile URL, and moves to using the US Core Head Circumference Percentile Profile instead.

Testing steps:
* verify that no references to the base FHIR Head Circumference profile remain (`http://hl7.org/fhir/StructureDefinition/headcircum`)
* verify that exported patients no longer contain resources with these profiles on them
* Verify that there are at least two `Observation` resources in exported `mrburns` patients with the new US Core Head Circumference Percentile profile on them (`http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile`)--one with a `valueQuantity`, and one with a `dataAbsentReason`
* Validate the patients (either through Inferno, or some other validator) and ensure the head circumference resources satisfy the required profiles

I can provide generated patients if desired.